### PR TITLE
Setup window parents to allow closing child on parent close

### DIFF
--- a/launcher/netplay/netplay.py
+++ b/launcher/netplay/netplay.py
@@ -5,7 +5,6 @@ import uuid
 import socket
 
 import requests
-from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QTimer
 
 from fsgs.amiga.amiga import Amiga
@@ -324,10 +323,9 @@ class Netplay:
             self.irc.warning("syntax: /reset")
             return
         # Get info before resetting config
-        game_id = LauncherConfig.get("__netplay_game")
-        port = LauncherConfig.get("__netplay_port")
-        channel = self.game_channel
-        close_server_window(game_id, port, channel)
+        if self.game_window:
+            self.game_window.close()
+            self.game_window = None
         self.reset_netplay_config()
         self.connection_tester = None
 
@@ -561,8 +559,8 @@ class Netplay:
             from ..server.ServerWindow import ServerWindow
             game_id = str(uuid.uuid4())
             channel_name = self.irc.get_active_channel()
-            window = ServerWindow(self.parent, server, game_id, port, channel_name)
-            window.show()
+            self.game_window = ServerWindow(self.parent, server, game_id, port, channel_name)
+            self.game_window.show()
             LauncherConfig.set_multiple(
                 [
                     ("__netplay_game", game_id),
@@ -877,11 +875,3 @@ class Netplay:
         file_config[
             "x_hard_drive_{0}_sha1".format(i)
         ] = "hard_drive_{0}".format(i)
-
-def close_server_window(game_id, port, channel):
-    title = f"FS-UAE Netplay Server - Game ID: {game_id}, Port: {port}, Channel: {channel}"
-    for widget in QApplication.topLevelWidgets():
-        if widget.windowTitle() == title:
-            widget.close()
-            return True
-    return False

--- a/launcher/netplay/netplay.py
+++ b/launcher/netplay/netplay.py
@@ -36,13 +36,14 @@ class Netplay:
             random.shuffle(cls.host_ports)
         return cls.host_ports.pop()
 
-    def __init__(self):
+    def __init__(self, parent=None):
         self.enabled = False
         self.game_channel = ""
         self.connection_tester = None
         self.start_sequence = ""
         self.players = {}
         self.irc = IRC()
+        self.parent = parent
 
         LauncherConfig.add_listener(self)
         IRCBroadcaster.add_listener(self)
@@ -560,7 +561,7 @@ class Netplay:
             from ..server.ServerWindow import ServerWindow
             game_id = str(uuid.uuid4())
             channel_name = self.irc.get_active_channel()
-            window = ServerWindow(None, server, game_id, port, channel_name)
+            window = ServerWindow(self.parent, server, game_id, port, channel_name)
             window.show()
             LauncherConfig.set_multiple(
                 [

--- a/launcher/netplay/netplay_dialog.py
+++ b/launcher/netplay/netplay_dialog.py
@@ -18,5 +18,5 @@ class NetplayDialog(fsui.Window):
         self.panel = NetplayPanel(self, header=False)
         self.layout.add(self.panel, expand=True, fill=True)
 
-        self.panel.set_min_size((1030, 860))
+        self.panel.set_min_size((800, 600))
         self.panel.on_show()

--- a/launcher/netplay/netplay_panel.py
+++ b/launcher/netplay/netplay_panel.py
@@ -15,11 +15,6 @@ from launcher.sync_settings import sync_settings
 from launcher.launcher_config import LauncherConfig
 from PyQt5 import QtGui
 
-def close_windows_by_title(window_title):
-    for widget in QApplication.topLevelWidgets():
-        if widget.windowTitle().startswith(window_title):
-            widget.close()
-
 class NetplayPanel(fsui.Panel):
     def __init__(self, parent, header=True):
         fsui.Panel.__init__(self, parent)
@@ -55,7 +50,7 @@ class NetplayPanel(fsui.Panel):
             self.text_area, fill=True, expand=True, margin=10, margin_left=0
         )
 
-        self.netplay = Netplay()
+        self.netplay = Netplay(parent=self)
         IRCBroadcaster.add_listener(self)
 
         self._build_netplay_game_inputs()
@@ -134,8 +129,6 @@ class NetplayPanel(fsui.Panel):
         print("NetplayPanel.on_destroy")
         IRCBroadcaster.remove_listener(self)
         self.netplay.disconnect()
-        close_windows_by_title("FS-UAE Netplay Server - Game ID:")
-        close_windows_by_title("Netplay Info")
 
     def on_show(self):
         # FIXME: currently disabled

--- a/launcher/ui/launch.py
+++ b/launcher/ui/launch.py
@@ -7,12 +7,8 @@ from launcher.i18n import gettext
 from launcher.launcher_config import LauncherConfig
 from launcher.launcher_settings import LauncherSettings
 from launcher.option import Option
-from launcher.settings.fullscreenmodebutton import FullscreenModeButton
-from launcher.settings.monitorbutton import MonitorButton
 from launcher.settings.override_warning import OverrideWarning
-from launcher.settings.videosynccheckbox import VideoSyncCheckBox
 from launcher.ui.behaviors.settingsbehavior import SettingsBehavior
-from launcher.netplay.netplay import close_server_window, Netplay
 
 
 class LaunchGroup(fsui.Group):
@@ -263,8 +259,6 @@ class LaunchDialog(fsui.Window):
     def __closed(self):
         LauncherConfig.set("__running", "")
         self.cancel()
-        # Use cached netplay info
-        close_server_window(self.netplay_game_id, self.netplay_port, self.netplay_channel)
         return False
 
     def on_progress(self, progress):

--- a/launcher/ui/launcherwindow.py
+++ b/launcher/ui/launcherwindow.py
@@ -826,4 +826,4 @@ class LauncherWindow(WindowWithTabs):
 
     def on_net_play(self):
         print("on_net_play")
-        NetplayDialog.open()
+        NetplayDialog.open(self)


### PR DESCRIPTION
- Setup netplay panel and ServerWindows parent relationships
- Assign server window to local Netplay() variable on launch
- Close ServerWindow if reset is called, using local server window variable
- Remove unused close_server_window() function.
- Tidy imports
closes #19, #30